### PR TITLE
Update GitHub Actions to use specific commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,15 +34,15 @@ jobs:
 
       - name: Initialize CodeQL
         id: initialize
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@39edc49
         with:
           languages: ${{ matrix.language }}
           source-root: src
 
       - name: Autobuild
         id: autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@39edc49
 
       - name: Perform CodeQL Analysis
         id: analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@39edc49

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,15 +34,15 @@ jobs:
 
       - name: Initialize CodeQL
         id: initialize
-        uses: github/codeql-action/init@39edc49
+        uses: github/codeql-action/init@39edc492dbe16b1465b0cafca41432d857bdb31a
         with:
           languages: ${{ matrix.language }}
           source-root: src
 
       - name: Autobuild
         id: autobuild
-        uses: github/codeql-action/autobuild@39edc49
+        uses: github/codeql-action/autobuild@39edc492dbe16b1465b0cafca41432d857bdb31a
 
       - name: Perform CodeQL Analysis
         id: analyze
-        uses: github/codeql-action/analyze@39edc49
+        uses: github/codeql-action/analyze@39edc492dbe16b1465b0cafca41432d857bdb31a

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Setup Ruby
         id: setup-ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651
         with:
           ruby-version: ruby
 
-      - uses: licensee/setup-licensed@v1.3.2
+      - uses: licensee/setup-licensed@0d52e57
         with:
           version: 4.x
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           ruby-version: ruby
 
-      - uses: licensee/setup-licensed@0d52e57
+      - uses: licensee/setup-licensed@0d52e575b3258417672be0dff2f115d7db8771d8
         with:
           version: 4.x
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@1215045
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@1215045
+        uses: super-linter/super-linter/slim@12150456a73e248bdc94d0794898f94e23127c88
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*


### PR DESCRIPTION
Replaces version tags with specific commit SHAs for actions in codeql-analysis.yml, licensed.yml, and linter.yml workflows. This improves security and reproducibility by pinning action versions.