### PR TITLE
Fix: Exclude Dependabot PRs from Claude review and refactor workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,6 @@ jobs:
 
       - name: Print Output
         id: output
-        run: echo "${{ steps.test-action.outputs.time }}"
+        env:
+          ACTION_TIME: ${{ steps.test-action.outputs.time }}
+        run: echo "$ACTION_TIME"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude-review:
+    # Exclude Dependabot PRs to avoid OIDC authentication errors
+    if: github.actor != 'dependabot[bot]'
+    
     # Optional: Filter by PR author
     # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.actor != 'dependabot[bot]' &&
+    #   (github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR')
 
     runs-on: ubuntu-latest
     permissions: # checkov:skip=CKV2_GHA_1 id-token write permission is required for OIDC authentication with Claude


### PR DESCRIPTION
## Summary

This PR fixes the Claude Code Review failures occurring on Dependabot PRs and includes a workflow refactoring.

## Problem

Dependabot PRs (#22, #23, #24) were failing with OIDC authentication errors:
```
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

## Solution

1. **Exclude Dependabot PRs from Claude review**: Added `if: github.actor \!= 'dependabot[bot]'` condition to the claude-review job to skip execution for Dependabot PRs
2. **Refactor workflow**: Updated `ci.yml` to use environment variables instead of direct context references in run sections

## Changes

- Modified `.github/workflows/claude-code-review.yml` to exclude Dependabot PRs
- Refactored `.github/workflows/ci.yml` to use environment variable for better security and maintainability

## Impact

- Normal PRs: Claude Code Review continues to work as expected
- Dependabot PRs: Claude Code Review is skipped, avoiding authentication errors
- Improved security by preventing potential command injection vulnerabilities
- Better script readability

## Related Issues

Fixes the Claude review failures in:
- #22
- #23
- #24

This approach follows the same pattern successfully implemented in https://github.com/VeyronSakai/get-job-summary-action/pull/20